### PR TITLE
fix(engine): allows for passing of `encodeOpts` in `sendRequest/Result`

### DIFF
--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -99,8 +99,8 @@ export class AuthEngine extends IAuthEngine {
     await this.client.pairing.set(pairingTopic, pairing);
 
     // SPEC: A generates keyPair X and generates response topic
-    let pubKey = await this.client.core.crypto.generateKeyPair();
-    let responseTopic = hashKey(pubKey);
+    const pubKey = await this.client.core.crypto.generateKeyPair();
+    const responseTopic = hashKey(pubKey);
 
     // Subscribe to response topic
     await this.client.core.relayer.subscribe(responseTopic);
@@ -157,31 +157,31 @@ export class AuthEngine extends IAuthEngine {
     this.client.expirer.set(topic, expiry);
   };
 
-  protected sendRequest: IAuthEngine["sendRequest"] = async (topic, method, params) => {
+  protected sendRequest: IAuthEngine["sendRequest"] = async (topic, method, params, encodeOpts) => {
     const payload = formatJsonRpcRequest(method, params);
-    const message = await this.client.core.crypto.encode(topic, payload);
-    const opts = ENGINE_RPC_OPTS[method].req;
-    await this.client.core.relayer.publish(topic, message, opts);
+    const message = await this.client.core.crypto.encode(topic, payload, encodeOpts);
+    const rpcOpts = ENGINE_RPC_OPTS[method].req;
+    await this.client.core.relayer.publish(topic, message, rpcOpts);
     this.client.history.set(topic, payload);
 
     return payload.id;
   };
 
-  protected sendResult: IAuthEngine["sendResult"] = async (id, topic, result) => {
+  protected sendResult: IAuthEngine["sendResult"] = async (id, topic, result, encodeOpts) => {
     const payload = formatJsonRpcResult(id, result);
-    const message = await this.client.core.crypto.encode(topic, payload);
+    const message = await this.client.core.crypto.encode(topic, payload, encodeOpts);
     const record = await this.client.history.get(topic, id);
-    const opts = ENGINE_RPC_OPTS[record.request.method].res;
-    await this.client.core.relayer.publish(topic, message, opts);
+    const rpcOpts = ENGINE_RPC_OPTS[record.request.method].res;
+    await this.client.core.relayer.publish(topic, message, rpcOpts);
     await this.client.history.resolve(payload);
   };
 
-  protected sendError: IAuthEngine["sendError"] = async (id, topic, error) => {
+  protected sendError: IAuthEngine["sendError"] = async (id, topic, error, encodeOpts) => {
     const payload = formatJsonRpcError(id, error);
-    const message = await this.client.core.crypto.encode(topic, payload);
+    const message = await this.client.core.crypto.encode(topic, payload, encodeOpts);
     const record = await this.client.history.get(topic, id);
-    const opts = ENGINE_RPC_OPTS[record.request.method].res;
-    await this.client.core.relayer.publish(topic, message, opts);
+    const rpcOpts = ENGINE_RPC_OPTS[record.request.method].res;
+    await this.client.core.relayer.publish(topic, message, rpcOpts);
     await this.client.history.resolve(payload);
   };
 

--- a/packages/auth-client/src/types/engine.ts
+++ b/packages/auth-client/src/types/engine.ts
@@ -45,7 +45,7 @@ export abstract class IAuthEngine {
     method: M,
     // params: JsonRpcTypes.RequestParams[M]
     params: any,
-    opts?: CryptoTypes.EncodeOptions,
+    encodeOpts?: CryptoTypes.EncodeOptions,
   ): Promise<number>;
 
   // @ts-expect-error - needs Results interface
@@ -54,7 +54,7 @@ export abstract class IAuthEngine {
     topic: string,
     // result: JsonRpcTypes.Results[M]
     result: any,
-    opts?: CryptoTypes.EncodeOptions,
+    encodeOpts?: CryptoTypes.EncodeOptions,
   ): Promise<void>;
 
   protected abstract sendError(


### PR DESCRIPTION
Context: needed for us to specify e.g. `TYPE_1` envelope option and pass sender/receiver pubKeys