### PR TITLE
fix(build): TS errors

### DIFF
--- a/packages/auth-client/src/types/client.ts
+++ b/packages/auth-client/src/types/client.ts
@@ -58,6 +58,7 @@ export abstract class IAuthClient {
     number,
     { id: number } & (AuthEngineTypes.Cacao | AuthEngineTypes.PendingRequest)
   >;
+
   public abstract pairing: Pairing;
   public abstract expirer: Expirer;
   public abstract events: EventEmitter;

--- a/packages/auth-client/src/types/engine.ts
+++ b/packages/auth-client/src/types/engine.ts
@@ -1,4 +1,4 @@
-import { RelayerTypes, CryptoTypes, CoreTypes } from "@walletconnect/types";
+import { RelayerTypes, CryptoTypes } from "@walletconnect/types";
 
 import {
   ErrorResponse,
@@ -7,7 +7,7 @@ import {
   JsonRpcResponse,
   JsonRpcResult,
 } from "@walletconnect/jsonrpc-utils";
-import { AuthClientTypes, IAuthClient } from "./client";
+import { IAuthClient } from "./client";
 import { JsonRpcTypes } from "./jsonrpc";
 
 export interface RpcOpts {


### PR DESCRIPTION
@devceline I think this is happening to us because we don't have a CI setup here yet and we don't always run the build locally before PRs + maybe neovim isn't showing you the TS errors etc.

Maybe something to also talk to Derek about re:getting a similar CI setup as in the monorepo where we can create a dedicated instance of the relay inside the test. I had a look a while back but the setup for Sign is pretty intense, so maybe he knows a simple way for us to get started with a running CI here.

Simplest thing would be to just run CI against the staging relay but that of course creates external points of failure.

