### PR TITLE
feat: adds npm publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - `prettier` - Runs [prettier](https://prettier.io/) checks
 - `build` - Builds all packages
 - `test` - Tests all packages
+- `npm-publish` - Publishes packages to NPM. Requires an OTP code to be input on publish.
 
 ## Unit Tests
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "prettier:write": "npm run prettier:write --workspaces",
     "build": "npm run clean --workspaces; npm run build --workspaces",
     "test": "npm run test --workspaces",
-    "test:watch": "npm run test:watch --workspaces"
+    "test:watch": "npm run test:watch --workspaces",
+    "npm-publish": "npm publish --access public --workspaces"
   },
   "engines": {
     "node": "16"

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -28,7 +28,8 @@
     "test:pre": "rm -rf ./test/test.db",
     "test:run": "vitest run --dir test",
     "test": "npm run test:pre; npm run test:run",
-    "test:watch": "vitest watch --dir test"
+    "test:watch": "vitest watch --dir test",
+    "prepublishOnly": "npm run build"
   },
   "engines": {
     "node": "16"


### PR DESCRIPTION
# Description

- Can be run at repo top-level via `npm run npm-publish`
- Will auto-rebuild the package before publishing via `prepublishOnly` script
- Initial `v0.1.0` has now been published: https://www.npmjs.com/package/@walletconnect/auth-client

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?

Tested locally

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
