### PR TITLE
chore: removes remaining `opts?`, use type in constructor

### DIFF
--- a/packages/auth-client/src/client.ts
+++ b/packages/auth-client/src/client.ts
@@ -42,11 +42,11 @@ export class AuthClient extends IAuthClient {
     super(opts);
 
     const logger =
-      typeof opts?.logger !== "undefined" && typeof opts?.logger !== "string"
+      typeof opts.logger !== "undefined" && typeof opts.logger !== "string"
         ? opts.logger
         : pino(
             getDefaultLoggerOptions({
-              level: opts?.logger || "error",
+              level: opts.logger || "error",
             }),
           );
 
@@ -65,7 +65,7 @@ export class AuthClient extends IAuthClient {
     this.expirer = new Expirer(this.core, this.logger);
     this.engine = new AuthEngine(this);
     this.history = new JsonRpcHistory(this.core, this.logger);
-    this.address = opts?.iss;
+    this.address = opts.iss;
   }
 
   get context() {

--- a/packages/auth-client/src/types/client.ts
+++ b/packages/auth-client/src/types/client.ts
@@ -67,7 +67,7 @@ export abstract class IAuthClient {
   public abstract history: IJsonRpcHistory;
   public abstract address: string | undefined;
 
-  constructor(public opts?: Record<string, any>) {}
+  constructor(public opts: AuthClientTypes.Options) {}
 
   // ---------- Public Methods ----------------------------------------------- //
 


### PR DESCRIPTION
# Description

- Quick follow-up to #24 

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?

- Ran tests locally

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
