### PR TITLE
fix(engine): use `core.version` instead of `client.version` in URI

### DIFF
--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -137,7 +137,7 @@ export class AuthEngine extends IAuthEngine {
 
     const uri = formatUri({
       protocol: this.client.protocol,
-      version: this.client.version,
+      version: this.client.core.version,
       topic: pairingTopic,
       symKey,
       relay,


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves # ([browse](https://github.com/WalletConnect/walletconnect-monorepo/issues) or [create](https://github.com/WalletConnect/walletconnect-monorepo/issues/new/choose))

## How Has This Been Tested?

- Ran existing UTs locally

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
