### PR TITLE
feat(utils): adds generateNonce util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5276,6 +5276,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@stablelib/random": "1.0.2",
         "@walletconnect/core": "2.0.0-rc.2",
         "@walletconnect/events": "1.0.0",
         "@walletconnect/heartbeat": "1.0.0",
@@ -5298,6 +5299,15 @@
       },
       "engines": {
         "node": "16"
+      }
+    },
+    "packages/auth-client/node_modules/@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
       }
     },
     "packages/auth-client/node_modules/events": {
@@ -6097,6 +6107,7 @@
     "@walletconnect/auth-client": {
       "version": "file:packages/auth-client",
       "requires": {
+        "@stablelib/random": "1.0.2",
         "@walletconnect/core": "2.0.0-rc.2",
         "@walletconnect/events": "1.0.0",
         "@walletconnect/heartbeat": "1.0.0",
@@ -6116,6 +6127,15 @@
         "pino-pretty": "4.3.0"
       },
       "dependencies": {
+        "@stablelib/random": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+          "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+          "requires": {
+            "@stablelib/binary": "^1.0.1",
+            "@stablelib/wipe": "^1.0.1"
+          }
+        },
         "events": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -35,6 +35,7 @@
     "node": "16"
   },
   "dependencies": {
+    "@stablelib/random": "1.0.2",
     "@walletconnect/core": "2.0.0-rc.2",
     "@walletconnect/events": "1.0.0",
     "@walletconnect/heartbeat": "1.0.0",

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -2,6 +2,7 @@ import { AuthClient as Client } from "./client";
 
 export * from "./constants";
 export * from "./types";
+export * from "./utils/crypto";
 
 export const AuthClient = Client;
 export default Client;

--- a/packages/auth-client/src/utils/crypto.ts
+++ b/packages/auth-client/src/utils/crypto.ts
@@ -1,0 +1,7 @@
+import { randomStringForEntropy } from "@stablelib/random";
+
+// Reference implementation:
+// https://github.com/spruceid/siwe/blob/38140330e54af91b1fab8ba1a8169e1fcbd8d271/packages/siwe/lib/utils.ts#L44
+export function generateNonce(): string {
+  return randomStringForEntropy(96);
+}

--- a/packages/auth-client/test/client.spec.ts
+++ b/packages/auth-client/test/client.spec.ts
@@ -1,7 +1,6 @@
 import { expect, describe, it, beforeEach, beforeAll, vi } from "vitest";
 import ethers from "ethers";
-import { AuthClient } from "../src/client";
-import { AuthEngineTypes } from "../src/types";
+import { AuthClient, generateNonce, IAuthClient, AuthEngineTypes } from "../src";
 
 const metadataRequester = {
   name: "client (requester)",
@@ -21,7 +20,7 @@ const defaultRequestParams: AuthEngineTypes.RequestParams = {
   aud: "http://localhost:3000/login",
   domain: "localhost:3000",
   chainId: "eip155:1",
-  nonce: "nonce",
+  nonce: generateNonce(),
 };
 
 const waitForRelay = async (waitTimeOverride?: number) => {
@@ -45,8 +44,8 @@ const waitForEvent = async (checkForEvent: (...args: any[]) => boolean) => {
 };
 
 describe("AuthClient", () => {
-  let client: AuthClient;
-  let peer: AuthClient;
+  let client: IAuthClient;
+  let peer: IAuthClient;
   let wallet: ethers.Wallet;
 
   // Mocking five minutes to be five seconds to test expiry.


### PR DESCRIPTION
# Description

- Implements and exposes `generateNonce` util based on `spruceid/siwe` reference implementation
- Also: export auth-specific types

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
