### PR TITLE
refactor(deps): minimise ethers dep size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,36 +59,10 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@ethersproject/abi": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
-      "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
-      }
-    },
     "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
-      "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "funding": [
         {
           "type": "individual",
@@ -100,19 +74,19 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -124,17 +98,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/address": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "funding": [
         {
           "type": "individual",
@@ -146,17 +120,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/base64": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
-      "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "funding": [
         {
           "type": "individual",
@@ -168,13 +142,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/basex": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
-      "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "funding": [
         {
           "type": "individual",
@@ -186,14 +160,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-      "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "funding": [
         {
           "type": "individual",
@@ -205,15 +179,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "bn.js": "^5.2.1"
       }
     },
     "node_modules/@ethersproject/bytes": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "funding": [
         {
           "type": "individual",
@@ -225,13 +199,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/constants": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
-      "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "funding": [
         {
           "type": "individual",
@@ -243,40 +217,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2"
-      }
-    },
-    "node_modules/@ethersproject/contracts": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
-      "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "^5.6.3",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
-      "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "funding": [
         {
           "type": "individual",
@@ -288,20 +235,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hdnode": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
-      "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "funding": [
         {
           "type": "individual",
@@ -313,24 +261,24 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/json-wallets": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
-      "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "funding": [
         {
           "type": "individual",
@@ -342,25 +290,25 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "node_modules/@ethersproject/keccak256": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-      "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "funding": [
         {
           "type": "individual",
@@ -372,14 +320,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
       }
     },
     "node_modules/@ethersproject/logger": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
       "funding": [
         {
           "type": "individual",
@@ -392,9 +340,9 @@
       ]
     },
     "node_modules/@ethersproject/networks": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
-      "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "funding": [
         {
           "type": "individual",
@@ -406,13 +354,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
-      "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "funding": [
         {
           "type": "individual",
@@ -424,14 +372,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "funding": [
         {
           "type": "individual",
@@ -443,70 +391,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "node_modules/@ethersproject/providers": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
-      "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      }
-    },
-    "node_modules/@ethersproject/providers/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/random": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
-      "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "funding": [
         {
           "type": "individual",
@@ -518,14 +409,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-      "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "funding": [
         {
           "type": "individual",
@@ -537,14 +428,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/sha2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
-      "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "funding": [
         {
           "type": "individual",
@@ -556,15 +447,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "funding": [
         {
           "type": "individual",
@@ -576,41 +467,18 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
-    "node_modules/@ethersproject/solidity": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
-      "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1"
-      }
-    },
     "node_modules/@ethersproject/strings": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
-      "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "funding": [
         {
           "type": "individual",
@@ -622,15 +490,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/transactions": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
-      "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "funding": [
         {
           "type": "individual",
@@ -642,41 +510,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2"
-      }
-    },
-    "node_modules/@ethersproject/units": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
-      "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wallet": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
-      "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "funding": [
         {
           "type": "individual",
@@ -688,27 +536,27 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/json-wallets": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/web": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
-      "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "funding": [
         {
           "type": "individual",
@@ -720,17 +568,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wordlists": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
-      "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "funding": [
         {
           "type": "individual",
@@ -742,11 +590,11 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@hapi/bourne": {
@@ -1779,11 +1627,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/better-sqlite3": {
       "version": "7.6.2",
@@ -2836,53 +2679,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ethers": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
-      "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/abstract-provider": "5.6.1",
-        "@ethersproject/abstract-signer": "5.6.2",
-        "@ethersproject/address": "5.6.1",
-        "@ethersproject/base64": "5.6.1",
-        "@ethersproject/basex": "5.6.1",
-        "@ethersproject/bignumber": "5.6.2",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.1",
-        "@ethersproject/contracts": "5.6.2",
-        "@ethersproject/hash": "5.6.1",
-        "@ethersproject/hdnode": "5.6.2",
-        "@ethersproject/json-wallets": "5.6.1",
-        "@ethersproject/keccak256": "5.6.1",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.4",
-        "@ethersproject/pbkdf2": "5.6.1",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.8",
-        "@ethersproject/random": "5.6.1",
-        "@ethersproject/rlp": "5.6.1",
-        "@ethersproject/sha2": "5.6.1",
-        "@ethersproject/signing-key": "5.6.2",
-        "@ethersproject/solidity": "5.6.1",
-        "@ethersproject/strings": "5.6.1",
-        "@ethersproject/transactions": "5.6.2",
-        "@ethersproject/units": "5.6.1",
-        "@ethersproject/wallet": "5.6.2",
-        "@ethersproject/web": "5.6.1",
-        "@ethersproject/wordlists": "5.6.1"
       }
     },
     "node_modules/events": {
@@ -5276,6 +5072,7 @@
       "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ethersproject/wallet": "^5.7.0",
         "@stablelib/random": "1.0.2",
         "@walletconnect/core": "2.0.0-rc.2",
         "@walletconnect/events": "1.0.0",
@@ -5285,7 +5082,6 @@
         "@walletconnect/logger": "1.0.1",
         "@walletconnect/time": "1.0.1",
         "@walletconnect/utils": "2.0.0-rc.2",
-        "ethers": "^5.6.9",
         "events": "^3.3.0",
         "pino": "6.7.0",
         "pino-pretty": "4.3.0"
@@ -5335,382 +5131,292 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@ethersproject/abi": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
-      "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
-      "requires": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
-      }
-    },
     "@ethersproject/abstract-provider": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
-      "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
-      "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
-      "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
-      "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
-      "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
-      "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "bn.js": "^5.2.1"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
-      "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
-      "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.6.2"
-      }
-    },
-    "@ethersproject/contracts": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
-      "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
-      "requires": {
-        "@ethersproject/abi": "^5.6.3",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/transactions": "^5.6.2"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
-      "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
-      "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
-      "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/pbkdf2": "^5.6.1",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
-      "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
+        "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
     },
     "@ethersproject/networks": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
-      "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
-      "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
-      "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "requires": {
-        "@ethersproject/logger": "^5.6.0"
-      }
-    },
-    "@ethersproject/providers": {
-      "version": "5.6.8",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
-      "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/basex": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/networks": "^5.6.3",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/web": "^5.6.1",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "requires": {}
-        }
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/random": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
-      "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
-      "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
-      "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
-      "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
-    "@ethersproject/solidity": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
-      "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/sha2": "^5.6.1",
-        "@ethersproject/strings": "^5.6.1"
-      }
-    },
     "@ethersproject/strings": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
-      "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
-      "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "requires": {
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/rlp": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2"
-      }
-    },
-    "@ethersproject/units": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
-      "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/constants": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
-      "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2",
-        "@ethersproject/address": "^5.6.1",
-        "@ethersproject/bignumber": "^5.6.2",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/hdnode": "^5.6.2",
-        "@ethersproject/json-wallets": "^5.6.1",
-        "@ethersproject/keccak256": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/random": "^5.6.1",
-        "@ethersproject/signing-key": "^5.6.2",
-        "@ethersproject/transactions": "^5.6.2",
-        "@ethersproject/wordlists": "^5.6.1"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/web": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
-      "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "requires": {
-        "@ethersproject/base64": "^5.6.1",
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
-      "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "requires": {
-        "@ethersproject/bytes": "^5.6.1",
-        "@ethersproject/hash": "^5.6.1",
-        "@ethersproject/logger": "^5.6.0",
-        "@ethersproject/properties": "^5.6.0",
-        "@ethersproject/strings": "^5.6.1"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@hapi/bourne": {
@@ -6107,6 +5813,7 @@
     "@walletconnect/auth-client": {
       "version": "file:packages/auth-client",
       "requires": {
+        "@ethersproject/wallet": "^5.7.0",
         "@stablelib/random": "1.0.2",
         "@walletconnect/core": "2.0.0-rc.2",
         "@walletconnect/events": "1.0.0",
@@ -6121,7 +5828,6 @@
         "@walletconnect/utils": "2.0.0-rc.2",
         "aws-sdk": "^2.1169.0",
         "better-sqlite3": "7.6.2",
-        "ethers": "^5.6.9",
         "events": "^3.3.0",
         "pino": "6.7.0",
         "pino-pretty": "4.3.0"
@@ -6471,11 +6177,6 @@
     "base64-js": {
       "version": "1.5.1",
       "devOptional": true
-    },
-    "bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "better-sqlite3": {
       "version": "7.6.2",
@@ -7144,43 +6845,6 @@
     "esutils": {
       "version": "2.0.3",
       "dev": true
-    },
-    "ethers": {
-      "version": "5.6.9",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
-      "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
-      "requires": {
-        "@ethersproject/abi": "5.6.4",
-        "@ethersproject/abstract-provider": "5.6.1",
-        "@ethersproject/abstract-signer": "5.6.2",
-        "@ethersproject/address": "5.6.1",
-        "@ethersproject/base64": "5.6.1",
-        "@ethersproject/basex": "5.6.1",
-        "@ethersproject/bignumber": "5.6.2",
-        "@ethersproject/bytes": "5.6.1",
-        "@ethersproject/constants": "5.6.1",
-        "@ethersproject/contracts": "5.6.2",
-        "@ethersproject/hash": "5.6.1",
-        "@ethersproject/hdnode": "5.6.2",
-        "@ethersproject/json-wallets": "5.6.1",
-        "@ethersproject/keccak256": "5.6.1",
-        "@ethersproject/logger": "5.6.0",
-        "@ethersproject/networks": "5.6.4",
-        "@ethersproject/pbkdf2": "5.6.1",
-        "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.8",
-        "@ethersproject/random": "5.6.1",
-        "@ethersproject/rlp": "5.6.1",
-        "@ethersproject/sha2": "5.6.1",
-        "@ethersproject/signing-key": "5.6.2",
-        "@ethersproject/solidity": "5.6.1",
-        "@ethersproject/strings": "5.6.1",
-        "@ethersproject/transactions": "5.6.2",
-        "@ethersproject/units": "5.6.1",
-        "@ethersproject/wallet": "5.6.2",
-        "@ethersproject/web": "5.6.1",
-        "@ethersproject/wordlists": "5.6.1"
-      }
     },
     "events": {
       "version": "1.1.1",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -35,6 +35,7 @@
     "node": "16"
   },
   "dependencies": {
+    "@ethersproject/wallet": "^5.7.0",
     "@stablelib/random": "1.0.2",
     "@walletconnect/core": "2.0.0-rc.2",
     "@walletconnect/events": "1.0.0",
@@ -44,7 +45,6 @@
     "@walletconnect/logger": "1.0.1",
     "@walletconnect/time": "1.0.1",
     "@walletconnect/utils": "2.0.0-rc.2",
-    "ethers": "^5.6.9",
     "events": "^3.3.0",
     "pino": "6.7.0",
     "pino-pretty": "4.3.0"

--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -23,7 +23,7 @@ import {
   createDelayedPromise,
   engineEvent,
 } from "@walletconnect/utils";
-import { utils } from "ethers";
+import { verifyMessage } from "@ethersproject/wallet";
 import { JsonRpcTypes, IAuthEngine, AuthEngineTypes } from "../types";
 import { EXPIRER_EVENTS, AUTH_CLIENT_PUBLIC_KEY_NAME, ENGINE_RPC_OPTS } from "../constants";
 import { getDidAddress, getDidChainId } from "../utils/address";
@@ -481,7 +481,7 @@ export class AuthEngine extends IAuthEngine {
       console.log("payload.iss:", payload.iss);
       console.log("signature:", signature);
 
-      const address = utils.verifyMessage(reconstructed, signature.s);
+      const address = verifyMessage(reconstructed, signature.s);
       const walletAddress = getDidAddress(payload.iss);
 
       console.log("Recovered address from signature:", address);

--- a/packages/auth-client/test/client.spec.ts
+++ b/packages/auth-client/test/client.spec.ts
@@ -1,5 +1,5 @@
 import { expect, describe, it, beforeEach, beforeAll, vi } from "vitest";
-import ethers from "ethers";
+import { Wallet } from "@ethersproject/wallet";
 import { AuthClient, generateNonce, IAuthClient, AuthEngineTypes } from "../src";
 
 const metadataRequester = {
@@ -46,7 +46,7 @@ const waitForEvent = async (checkForEvent: (...args: any[]) => boolean) => {
 describe("AuthClient", () => {
   let client: IAuthClient;
   let peer: IAuthClient;
-  let wallet: ethers.Wallet;
+  let wallet: Wallet;
 
   // Mocking five minutes to be five seconds to test expiry.
   // Modified constant instead of functions to be as close as possible to actual
@@ -58,7 +58,7 @@ describe("AuthClient", () => {
 
   // Set up a wallet to use as the external signer.
   beforeAll(() => {
-    wallet = ethers.Wallet.createRandom();
+    wallet = Wallet.createRandom();
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
# Description

- Since we only require `verifyMessage` for the actual pkg, and only `ethers.Wallet` in the tests, we can reduce our `ethers` dependency down from the umbrella package to `@ethersproject/wallet` specifically.
- Before: https://bundlephobia.com/package/ethers@5.7.1
- After: https://bundlephobia.com/package/@ethersproject/wallet@5.7.0

## How Has This Been Tested?

- Unit tests and build locally
- In CI here

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
