### PR TITLE
feat: implements EIP-1271 sig validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,32 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
     "node_modules/@ethersproject/abstract-provider": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
@@ -220,6 +246,33 @@
         "@ethersproject/bignumber": "^5.7.0"
       }
     },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
+      }
+    },
     "node_modules/@ethersproject/hash": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
@@ -250,6 +303,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
       "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -279,6 +333,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
       "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -361,6 +416,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
       "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -392,6 +448,63 @@
       ],
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.1.tgz",
+      "integrity": "sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ethersproject/random": {
@@ -525,6 +638,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
       "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -579,6 +693,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
       "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1349,7 +1464,8 @@
     "node_modules/aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "dev": true
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -1627,6 +1743,11 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/better-sqlite3": {
       "version": "7.6.2",
@@ -4396,7 +4517,8 @@
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.3.7",
@@ -5072,7 +5194,11 @@
       "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ethersproject/wallet": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/contracts": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/providers": "^5.7.1",
+        "@ethersproject/transactions": "^5.7.0",
         "@stablelib/random": "1.0.2",
         "@walletconnect/core": "2.0.0-rc.2",
         "@walletconnect/events": "1.0.0",
@@ -5087,6 +5213,7 @@
         "pino-pretty": "4.3.0"
       },
       "devDependencies": {
+        "@ethersproject/wallet": "^5.7.0",
         "@walletconnect/jsonrpc-ws-connection": "1.0.3",
         "@walletconnect/relay-api": "1.0.6",
         "@walletconnect/types": "2.0.0-rc.2",
@@ -5129,6 +5256,22 @@
         "js-yaml": "^4.1.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@ethersproject/abi": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "requires": {
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/abstract-provider": {
@@ -5212,6 +5355,23 @@
         "@ethersproject/bignumber": "^5.7.0"
       }
     },
+    "@ethersproject/contracts": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+      "requires": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
+      }
+    },
     "@ethersproject/hash": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
@@ -5232,6 +5392,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
       "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/basex": "^5.7.0",
@@ -5251,6 +5412,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
       "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -5293,6 +5455,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
       "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/sha2": "^5.7.0"
@@ -5304,6 +5467,41 @@
       "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "requires": {
         "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.1.tgz",
+      "integrity": "sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "requires": {}
+        }
       }
     },
     "@ethersproject/random": {
@@ -5377,6 +5575,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
       "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+      "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -5411,6 +5610,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
       "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+      "dev": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/hash": "^5.7.0",
@@ -5813,7 +6013,12 @@
     "@walletconnect/auth-client": {
       "version": "file:packages/auth-client",
       "requires": {
-        "@ethersproject/wallet": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/contracts": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/providers": "^5.7.1",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wallet": "*",
         "@stablelib/random": "1.0.2",
         "@walletconnect/core": "2.0.0-rc.2",
         "@walletconnect/events": "1.0.0",
@@ -6009,7 +6214,8 @@
     "aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -6177,6 +6383,11 @@
     "base64-js": {
       "version": "1.5.1",
       "devOptional": true
+    },
+    "bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "better-sqlite3": {
       "version": "7.6.2",
@@ -7890,7 +8101,8 @@
     "scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
     },
     "semver": {
       "version": "7.3.7",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -35,7 +35,11 @@
     "node": "16"
   },
   "dependencies": {
-    "@ethersproject/wallet": "^5.7.0",
+    "@ethersproject/bytes": "^5.7.0",
+    "@ethersproject/contracts": "^5.7.0",
+    "@ethersproject/hash": "^5.7.0",
+    "@ethersproject/providers": "^5.7.1",
+    "@ethersproject/transactions": "^5.7.0",
     "@stablelib/random": "1.0.2",
     "@walletconnect/core": "2.0.0-rc.2",
     "@walletconnect/events": "1.0.0",
@@ -50,6 +54,7 @@
     "pino-pretty": "4.3.0"
   },
   "devDependencies": {
+    "@ethersproject/wallet": "^5.7.0",
     "@walletconnect/jsonrpc-ws-connection": "1.0.3",
     "@walletconnect/relay-api": "1.0.6",
     "@walletconnect/types": "2.0.0-rc.2",

--- a/packages/auth-client/src/client.ts
+++ b/packages/auth-client/src/client.ts
@@ -25,6 +25,8 @@ export class AuthClient extends IAuthClient {
   public name: IAuthClient["name"] = AUTH_CLIENT_DEFAULT_NAME;
   public core: IAuthClient["core"];
   public metadata: IAuthClient["metadata"];
+  public address: IAuthClient["address"];
+  public projectId: IAuthClient["projectId"];
   public logger: IAuthClient["logger"];
   public events: IAuthClient["events"] = new EventEmitter();
   public engine: IAuthClient["engine"];
@@ -34,7 +36,6 @@ export class AuthClient extends IAuthClient {
   public authKeys: IAuthClient["authKeys"];
   public pairingTopics: IAuthClient["pairingTopics"];
   public requests: IAuthClient["requests"];
-  public address: IAuthClient["address"];
 
   static async init(opts: AuthClientTypes.Options) {
     const client = new AuthClient(opts);
@@ -57,6 +58,8 @@ export class AuthClient extends IAuthClient {
 
     this.name = opts?.name || AUTH_CLIENT_DEFAULT_NAME;
     this.metadata = opts.metadata;
+    this.address = opts.iss;
+    this.projectId = opts.projectId;
     this.core = opts.core || new Core(opts);
     this.logger = generateChildLogger(logger, this.name);
     this.authKeys = new Store(this.core, this.logger, "authKeys", AUTH_CLIENT_STORAGE_PREFIX);
@@ -71,7 +74,6 @@ export class AuthClient extends IAuthClient {
     this.expirer = new Expirer(this.core, this.logger);
     this.engine = new AuthEngine(this);
     this.history = new JsonRpcHistory(this.core, this.logger);
-    this.address = opts.iss;
   }
 
   get context() {

--- a/packages/auth-client/src/constants/defaults.ts
+++ b/packages/auth-client/src/constants/defaults.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_RPC_URL = "https://rpc.walletconnect.com/v1";

--- a/packages/auth-client/src/constants/index.ts
+++ b/packages/auth-client/src/constants/index.ts
@@ -1,3 +1,4 @@
+export * from "./defaults";
 export * from "./engine";
 export * from "./client";
 export * from "./history";

--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -23,13 +23,13 @@ import {
   createDelayedPromise,
   engineEvent,
 } from "@walletconnect/utils";
-import { verifyMessage } from "@ethersproject/wallet";
 import { JsonRpcTypes, IAuthEngine, AuthEngineTypes } from "../types";
 import { EXPIRER_EVENTS, AUTH_CLIENT_PUBLIC_KEY_NAME, ENGINE_RPC_OPTS } from "../constants";
-import { getDidAddress, getDidChainId } from "../utils/address";
+import { getDidAddress, getDidChainId, getNamespacedDidChainId } from "../utils/address";
 import { getPendingRequest, getPendingRequests } from "../utils/store";
 import { isValidPairUri, isValidRequest, isValidRespond } from "../utils/validators";
 import { formatUri, parseUri } from "../utils/uri";
+import { verifySignature } from "../utils/signature";
 
 export class AuthEngine extends IAuthEngine {
   private initialized = false;
@@ -481,13 +481,26 @@ export class AuthEngine extends IAuthEngine {
       console.log("payload.iss:", payload.iss);
       console.log("signature:", signature);
 
-      const address = verifyMessage(reconstructed, signature.s);
       const walletAddress = getDidAddress(payload.iss);
+      const chainId = getNamespacedDidChainId(payload.iss);
 
-      console.log("Recovered address from signature:", address);
+      if (!walletAddress) {
+        throw new Error("Could not derive address from `payload.iss`");
+      }
+      if (!chainId) {
+        throw new Error("Could not derive chainId from `payload.iss`");
+      }
       console.log("walletAddress extracted from `payload.iss`:", walletAddress);
 
-      if (address !== walletAddress) {
+      const isValid = await verifySignature(
+        walletAddress,
+        reconstructed,
+        signature,
+        chainId,
+        this.client.projectId,
+      );
+
+      if (!isValid) {
         this.client.emit("auth_response", {
           id,
           topic,

--- a/packages/auth-client/src/types/client.ts
+++ b/packages/auth-client/src/types/client.ts
@@ -46,6 +46,7 @@ export declare namespace AuthClientTypes {
     metadata: Metadata;
     core?: ICore;
     iss?: string;
+    projectId: string;
   }
 
   interface Metadata {
@@ -67,6 +68,8 @@ export abstract class IAuthClient {
 
   public abstract core: ICore;
   public abstract metadata: AuthClientTypes.Metadata;
+  public abstract address?: string;
+  public abstract projectId: string;
   public abstract authKeys: IStore<string, { publicKey: string }>;
   public abstract pairingTopics: IStore<string, any>;
   public abstract requests: IStore<
@@ -80,7 +83,6 @@ export abstract class IAuthClient {
   public abstract logger: Logger;
   public abstract engine: IAuthEngine;
   public abstract history: IJsonRpcHistory;
-  public abstract address: string | undefined;
 
   constructor(public opts: AuthClientTypes.Options) {}
 

--- a/packages/auth-client/src/types/engine.ts
+++ b/packages/auth-client/src/types/engine.ts
@@ -75,7 +75,7 @@ export declare namespace AuthEngineTypes {
   }
 
   interface CacaoSignature {
-    t: "eip191";
+    t: "eip191" | "eip1271";
     s: string;
     m?: string;
   }

--- a/packages/auth-client/src/utils/address.ts
+++ b/packages/auth-client/src/utils/address.ts
@@ -10,6 +10,14 @@ export function getDidChainId(iss: string) {
   return undefined;
 }
 
+export function getNamespacedDidChainId(iss: string) {
+  const segments = iss && getDidAddressSegments(iss);
+  if (segments) {
+    return segments[2] + ":" + segments[3];
+  }
+  return undefined;
+}
+
 export function getDidAddress(iss: string) {
   const segments = iss && getDidAddressSegments(iss);
   if (segments) {

--- a/packages/auth-client/src/utils/signature.ts
+++ b/packages/auth-client/src/utils/signature.ts
@@ -1,0 +1,89 @@
+import { JsonRpcProvider, Provider } from "@ethersproject/providers";
+import { hashMessage } from "@ethersproject/hash";
+import { recoverAddress } from "@ethersproject/transactions";
+import { Contract } from "@ethersproject/contracts";
+import { arrayify } from "@ethersproject/bytes";
+
+import { AuthEngineTypes } from "../types";
+import { DEFAULT_RPC_URL } from "../constants/defaults";
+
+export async function verifySignature(
+  address: string,
+  reconstructedMessage: string,
+  cacaoSignature: AuthEngineTypes.CacaoSignature,
+  chainId: string,
+  projectId: string,
+): Promise<boolean> {
+  // Determine if this address is an EOA or a contract.
+
+  switch (cacaoSignature.t) {
+    case "eip191":
+      return isValidEip191Signature(address, reconstructedMessage, cacaoSignature.s);
+    case "eip1271":
+      return await isValidEip1271Signature(
+        address,
+        reconstructedMessage,
+        cacaoSignature.s,
+        new JsonRpcProvider(`${DEFAULT_RPC_URL}/?chainId=${chainId}&projectId=${projectId}`),
+      );
+    default:
+      throw new Error(
+        `verifySignature failed: Attempted to verify CacaoSignature with unknown type: ${cacaoSignature.t}`,
+      );
+  }
+}
+
+function isValidEip191Signature(address: string, message: string, signature: string): boolean {
+  const recoveredAddress = recoverAddress(hashMessage(message), signature);
+  console.log("Recovered address from EIP-191 signature:", address);
+  return recoveredAddress.toLowerCase() === address.toLowerCase();
+}
+
+async function isValidEip1271Signature(
+  address: string,
+  reconstructedMessage: string,
+  signature: string,
+  provider: Provider,
+  abi = eip1271.abi,
+  magicValue = eip1271.magicValue,
+): Promise<boolean> {
+  try {
+    const recoveredValue = await new Contract(address, abi, provider).isValidSignature(
+      arrayify(hashMessage(reconstructedMessage)),
+      signature,
+    );
+    console.log("Recovered magic value from EIP-1271 signature:", recoveredValue);
+    return recoveredValue.toLowerCase() === magicValue.toLowerCase();
+  } catch (e) {
+    return false;
+  }
+}
+
+const eip1271 = {
+  magicValue: "0x1626ba7e",
+  abi: [
+    {
+      constant: true,
+      inputs: [
+        {
+          name: "_hash",
+          type: "bytes32",
+        },
+        {
+          name: "_sig",
+          type: "bytes",
+        },
+      ],
+      name: "isValidSignature",
+      outputs: [
+        {
+          name: "magicValue",
+          type: "bytes4",
+        },
+      ],
+      payable: false,
+      stateMutability: "view",
+      type: "function",
+    },
+  ],
+};

--- a/packages/auth-client/test/client.spec.ts
+++ b/packages/auth-client/test/client.spec.ts
@@ -66,7 +66,7 @@ describe("AuthClient", () => {
       name: "testClient",
       logger: "error",
       relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
-      projectId: process.env.TEST_PROJECT_ID,
+      projectId: process.env.TEST_PROJECT_ID!,
       storageOptions: {
         database: ":memory:",
       },
@@ -77,7 +77,7 @@ describe("AuthClient", () => {
       name: "testPeer",
       logger: "error",
       relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
-      projectId: process.env.TEST_PROJECT_ID,
+      projectId: process.env.TEST_PROJECT_ID!,
       storageOptions: {
         database: ":memory:",
       },
@@ -349,7 +349,7 @@ describe("AuthClient", () => {
     client = await AuthClient.init({
       logger: "error",
       relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
-      projectId: process.env.TEST_PROJECT_ID,
+      projectId: process.env.TEST_PROJECT_ID!,
       storageOptions: {
         database: ":memory:",
       },

--- a/packages/auth-client/test/signature.spec.ts
+++ b/packages/auth-client/test/signature.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { verifySignature } from "../src/utils/signature";
+import { AuthEngineTypes } from "../src/types";
+
+describe("utils/signature", () => {
+  describe("EIP-1271 signatures", () => {
+    const chainId = "eip155:1";
+    const projectId = process.env.TEST_PROJECT_ID!;
+    const address = "0x2faf83c542b68f1b4cdc0e770e8cb9f567b08f71";
+    const reconstructedMessage = `localhost wants you to sign in with your Ethereum account:
+0x2faf83c542b68f1b4cdc0e770e8cb9f567b08f71
+
+URI: http://localhost:3000/
+Version: 1
+Chain ID: 1
+Nonce: 1665443015700
+Issued At: 2022-10-10T23:03:35.700Z
+Expiration Time: 2022-10-11T23:03:35.700Z`;
+
+    it("passes for a valid signature", async () => {
+      const cacaoSignature: AuthEngineTypes.CacaoSignature = {
+        t: "eip1271",
+        s: "0xc1505719b2504095116db01baaf276361efd3a73c28cf8cc28dabefa945b8d536011289ac0a3b048600c1e692ff173ca944246cf7ceb319ac2262d27b395c82b1c",
+      };
+
+      const isValid = await verifySignature(
+        address,
+        reconstructedMessage,
+        cacaoSignature,
+        chainId,
+        projectId,
+      );
+      expect(isValid).toBe(true);
+    });
+    it("fails for a bad signature", async () => {
+      const cacaoSignature: AuthEngineTypes.CacaoSignature = {
+        t: "eip1271",
+        s: "0xdead5719b2504095116db01baaf276361efd3a73c28cf8cc28dabefa945b8d536011289ac0a3b048600c1e692ff173ca944246cf7ceb319ac2262d27b395c82b1c",
+      };
+
+      const isValid = await verifySignature(
+        address,
+        reconstructedMessage,
+        cacaoSignature,
+        chainId,
+        projectId,
+      );
+      expect(isValid).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Description

- Part of #43 
- Implements validation of [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) signatures.

## Sub-commits

```
feat(types): extend `CacaoSignature.t` with `eip1271`

feat: creates separate signature util

test: adds `signature.spec.ts` suite

feat(engine): adds support for EIP-1271 signatures
```

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

## How Has This Been Tested?

- Unit tests

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
