### PR TITLE
fix(tests): use disconnectSocket afterEach to teardown gracefully

### DIFF
--- a/packages/auth-client/test/client.spec.ts
+++ b/packages/auth-client/test/client.spec.ts
@@ -1,6 +1,7 @@
-import { expect, describe, it, beforeEach, beforeAll, vi } from "vitest";
+import { expect, describe, it, beforeEach, afterEach, beforeAll, vi } from "vitest";
 import { Wallet } from "@ethersproject/wallet";
 import { AuthClient, generateNonce, IAuthClient, AuthEngineTypes } from "../src";
+import { disconnectSocket } from "./helpers/ws";
 
 const metadataRequester = {
   name: "client (requester)",
@@ -84,6 +85,11 @@ describe("AuthClient", () => {
       iss: `did:pkh:eip155:1:${wallet.address}`,
       metadata: metadataResponder,
     });
+  });
+
+  afterEach(async () => {
+    await disconnectSocket(client.core);
+    await disconnectSocket(peer.core);
   });
 
   it("can be instantiated", () => {

--- a/packages/auth-client/test/helpers/ws.ts
+++ b/packages/auth-client/test/helpers/ws.ts
@@ -1,0 +1,18 @@
+import { IJsonRpcConnection } from "@walletconnect/jsonrpc-utils";
+import { ICore } from "@walletconnect/types";
+import EventEmitter from "events";
+
+export async function disconnectSocket(core: ICore) {
+  if (core.relayer.connected) {
+    core.relayer.provider.events = new EventEmitter();
+    core.relayer.core.heartbeat.events = new EventEmitter();
+    core.relayer.provider.connection.on("open", async () => {
+      await disconnect(core.relayer.provider.connection);
+    });
+    await disconnect(core.relayer.provider.connection);
+  }
+}
+
+function disconnect(socket: IJsonRpcConnection) {
+  return socket.close();
+}

--- a/packages/auth-client/test/validation.spec.ts
+++ b/packages/auth-client/test/validation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { AuthClient } from "../src/client";
 import { isValidRequest, isValidRespond } from "../src/utils/validators";
+import { disconnectSocket } from "./helpers/ws";
 
 const metadataRequester = {
   name: "client (requester)",
@@ -50,7 +51,7 @@ describe("Validation", () => {
       const client = await AuthClient.init({
         logger: "error",
         relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
-        projectId: process.env.TEST_PROJECT_ID,
+        projectId: process.env.TEST_PROJECT_ID!,
         storageOptions: {
           database: ":memory:",
         },
@@ -66,13 +67,14 @@ describe("Validation", () => {
 
       const isValid = isValidRespond({ id, signature: {} as any }, client.requests);
       expect(isValid).to.eql(true);
+      await disconnectSocket(client.core);
     });
 
     it("Validates bad case", async () => {
       const client = await AuthClient.init({
         logger: "error",
         relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
-        projectId: process.env.TEST_PROJECT_ID,
+        projectId: process.env.TEST_PROJECT_ID!,
         storageOptions: {
           database: ":memory:",
         },
@@ -81,6 +83,7 @@ describe("Validation", () => {
 
       const isValid = isValidRespond({ id: 2, signature: {} as any }, client.requests);
       expect(isValid).to.eql(false);
+      await disconnectSocket(client.core);
     });
   });
 });


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

- Occasionally see socket hang up issues in the CI tests here too
- Using `disconnectSocket` as we do in Sign should resolve this.

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
