### PR TITLE
Update engines, bump to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@walletconnect/auth-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@walletconnect/auth-client",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/auth-client"
@@ -37,7 +37,7 @@
         "vitest": "0.19.0"
       },
       "engines": {
-        "node": ">=14 <17"
+        "node": ">=14"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -4733,7 +4733,7 @@
     },
     "packages/auth-client": {
       "name": "@walletconnect/auth-client",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/hash": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/auth-client",
   "description": "WalletConnect Auth Client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "keywords": [
     "wallet",
@@ -34,7 +34,7 @@
     "npm-publish:canary": "npm publish --access public --tag canary --workspaces"
   },
   "engines": {
-    "node": ">=14 <17"
+    "node": ">=14"
   },
   "repository": {
     "type": "git",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from "vitest/config";
 
+// Node.js 16 is required to run the tests
+const versionRegex = new RegExp(`^${16}\\..*`);
+const versionCorrect = process.versions.node.match(versionRegex);
+if (!versionCorrect) {
+  throw Error(`Running on wrong Nodejs version. Please upgrade the node runtime to version ${16}`);
+}
+
 export default defineConfig({
   test: {
     testTimeout: 10_000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 const versionRegex = new RegExp(`^${16}\\..*`);
 const versionCorrect = process.versions.node.match(versionRegex);
 if (!versionCorrect) {
-  throw Error(`Running on wrong Nodejs version. Please upgrade the node runtime to version ${16}`);
+  throw Error(`Running on wrong Nodejs version. Please use node version 16.x`);
 }
 
 export default defineConfig({


### PR DESCRIPTION
# Description
Don't upper limit nodejs version, as this will cause install warnigs and errors on any node version above specified range.

## Due Dilligence
* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
