### PR TITLE
fix(engine): fixes known pairing request flow, use `pairing.create()` over pre-pairing API manual creation

### DIFF
--- a/packages/auth-client/src/client.ts
+++ b/packages/auth-client/src/client.ts
@@ -14,6 +14,7 @@ import {
   AUTH_CLIENT_STORAGE_PREFIX,
   AUTH_CLIENT_VERSION,
   AUTH_CLIENT_DEFAULT_NAME,
+  AUTH_CLIENT_PUBLIC_KEY_NAME,
 } from "./constants";
 
 export class AuthClient extends IAuthClient {
@@ -55,7 +56,13 @@ export class AuthClient extends IAuthClient {
     this.projectId = opts.projectId;
     this.core = opts.core || new Core(opts);
     this.logger = generateChildLogger(logger, this.name);
-    this.authKeys = new Store(this.core, this.logger, "authKeys", AUTH_CLIENT_STORAGE_PREFIX);
+    this.authKeys = new Store(
+      this.core,
+      this.logger,
+      "authKeys",
+      AUTH_CLIENT_STORAGE_PREFIX,
+      () => AUTH_CLIENT_PUBLIC_KEY_NAME,
+    );
     this.pairingTopics = new Store(
       this.core,
       this.logger,
@@ -143,6 +150,7 @@ export class AuthClient extends IAuthClient {
       await this.pairingTopics.init();
       await this.engine.init();
       this.logger.info(`AuthClient Initialization Success`);
+      this.logger.info({ authClient: this });
     } catch (error: any) {
       this.logger.info(`AuthClient Initialization Failure`);
       this.logger.error(error.message);

--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -60,7 +60,7 @@ export class AuthEngine extends IAuthEngine {
     const responseTopic = hashKey(publicKey);
 
     this.client.authKeys.set(AUTH_CLIENT_PUBLIC_KEY_NAME, { publicKey });
-    await this.client.pairingTopics.set(responseTopic, { pairingTopic });
+    await this.client.pairingTopics.set(responseTopic, { topic: responseTopic, pairingTopic });
 
     // Subscribe to auth_response topic
     await this.client.core.relayer.subscribe(responseTopic);

--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -43,7 +43,7 @@ export class AuthEngine extends IAuthEngine {
     }
 
     if (opts?.topic) {
-      return this.requestOnKnownPairing(opts.topic, params);
+      return await this.requestOnKnownPairing(opts.topic, params);
     }
 
     // SPEC: A will construct an authentication request.

--- a/packages/auth-client/src/types/engine.ts
+++ b/packages/auth-client/src/types/engine.ts
@@ -112,7 +112,7 @@ export abstract class IAuthEngine {
   public abstract request(
     params: AuthEngineTypes.RequestParams,
     opts?: { topic?: string },
-  ): Promise<{ uri: string; id: number }>;
+  ): Promise<{ uri?: string; id: number }>;
 
   public abstract respond(params: AuthEngineTypes.RespondParams, iss: string): Promise<void>;
 

--- a/packages/auth-client/test/canary/canary.spec.ts
+++ b/packages/auth-client/test/canary/canary.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect, describe, it, beforeEach, afterEach, beforeAll } from "vitest";
 import { Wallet } from "@ethersproject/wallet";
 import { AuthClient, generateNonce, IAuthClient, AuthEngineTypes } from "./../../src";
@@ -182,8 +183,6 @@ describe("AuthClient canary", () => {
         resolve();
       }),
     ]);
-
-    await peer.core.pairing.pair({ uri: request.uri! });
 
     const requests = peer.getPendingRequests();
 

--- a/packages/auth-client/test/canary/canary.spec.ts
+++ b/packages/auth-client/test/canary/canary.spec.ts
@@ -113,7 +113,7 @@ describe("AuthClient canary", () => {
         });
       }),
       new Promise<void>(async (resolve) => {
-        await peer.core.pairing.pair({ uri: request.uri, activatePairing: true });
+        await peer.core.pairing.pair({ uri: request.uri!, activatePairing: true });
         resolve();
       }),
     ]);
@@ -158,7 +158,7 @@ describe("AuthClient canary", () => {
         });
       }),
       new Promise<void>(async (resolve) => {
-        await peer.core.pairing.pair({ uri: request.uri });
+        await peer.core.pairing.pair({ uri: request.uri! });
         resolve();
       }),
     ]);
@@ -178,12 +178,12 @@ describe("AuthClient canary", () => {
         });
       }),
       new Promise<void>(async (resolve) => {
-        await peer.core.pairing.pair({ uri: request.uri });
+        await peer.core.pairing.pair({ uri: request.uri! });
         resolve();
       }),
     ]);
 
-    await peer.core.pairing.pair({ uri: request.uri });
+    await peer.core.pairing.pair({ uri: request.uri! });
 
     const requests = peer.getPendingRequests();
 

--- a/packages/auth-client/test/client.spec.ts
+++ b/packages/auth-client/test/client.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect, describe, it, beforeEach, afterEach, beforeAll } from "vitest";
 import { Wallet } from "@ethersproject/wallet";
 import { AuthClient, generateNonce, IAuthClient, AuthEngineTypes, AuthClientTypes } from "../src";

--- a/packages/auth-client/test/client.spec.ts
+++ b/packages/auth-client/test/client.spec.ts
@@ -64,7 +64,7 @@ describe("AuthClient", () => {
   beforeEach(async () => {
     client = await AuthClient.init({
       name: "testClient",
-      logger: "info",
+      logger: "error",
       relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
       projectId: process.env.TEST_PROJECT_ID!,
       storageOptions: {
@@ -75,7 +75,7 @@ describe("AuthClient", () => {
 
     peer = await AuthClient.init({
       name: "testPeer",
-      logger: "info",
+      logger: "error",
       relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
       projectId: process.env.TEST_PROJECT_ID!,
       storageOptions: {

--- a/packages/auth-client/test/client.spec.ts
+++ b/packages/auth-client/test/client.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
-import { expect, describe, it, beforeEach, afterEach, beforeAll, vi } from "vitest";
+import { expect, describe, it, beforeEach, afterEach, beforeAll } from "vitest";
 import { Wallet } from "@ethersproject/wallet";
-import { AuthClient, generateNonce, IAuthClient, AuthEngineTypes } from "../src";
+import { AuthClient, generateNonce, IAuthClient, AuthEngineTypes, AuthClientTypes } from "../src";
 import { disconnectSocket } from "./helpers/ws";
 import { RELAYER_EVENTS } from "@walletconnect/core";
 import { RelayerTypes } from "@walletconnect/types";
@@ -64,7 +64,7 @@ describe("AuthClient", () => {
   beforeEach(async () => {
     client = await AuthClient.init({
       name: "testClient",
-      logger: "error",
+      logger: "info",
       relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
       projectId: process.env.TEST_PROJECT_ID!,
       storageOptions: {
@@ -75,7 +75,7 @@ describe("AuthClient", () => {
 
     peer = await AuthClient.init({
       name: "testPeer",
-      logger: "error",
+      logger: "info",
       relayUrl: process.env.TEST_RELAY_URL || "wss://staging.relay.walletconnect.com",
       projectId: process.env.TEST_PROJECT_ID!,
       storageOptions: {
@@ -109,7 +109,7 @@ describe("AuthClient", () => {
     });
     const { uri } = await client.request(defaultRequestParams);
 
-    await peer.core.pairing.pair({ uri, activatePairing: true });
+    await peer.core.pairing.pair({ uri: uri!, activatePairing: true });
     await waitForEvent(() => hasRequest);
 
     // Ensure they paired
@@ -125,7 +125,7 @@ describe("AuthClient", () => {
   });
 
   it("can use known pairings", async () => {
-    let responseCount = 0;
+    const responses: AuthClientTypes.BaseEventArgs<AuthClientTypes.AuthResponseEventArgs>[] = [];
 
     peer.on("auth_request", async (args) => {
       const message = peer.formatMessage(args.params.cacaoPayload, iss);
@@ -142,26 +142,30 @@ describe("AuthClient", () => {
       );
     });
 
-    client.on("auth_response", async () => {
-      responseCount++;
+    client.on("auth_response", (args) => {
+      responses.push(args);
     });
 
     const { uri: uri1 } = await client.request(defaultRequestParams);
 
-    await peer.core.pairing.pair({ uri: uri1 });
+    await peer.core.pairing.pair({ uri: uri1! });
 
-    await waitForEvent(() => responseCount === 1);
+    await waitForEvent(() => responses.length === 1);
 
     const knownPairing = client.core.pairing.getPairings()[0];
 
     const { uri: uri2 } = await client.request(defaultRequestParams, { topic: knownPairing.topic });
 
-    await waitForEvent(() => responseCount === 2);
-    expect(uri1).not.to.eql(uri2);
+    await waitForEvent(() => responses.length === 2);
 
-    // Ensure they paired
+    expect(uri2).toBeUndefined();
+
+    // Ensure they paired correctly
+    expect(client.core.pairing.pairings.keys.length).to.eql(1);
+    expect(client.core.history.keys.length).to.eql(2);
     expect(peer.core.pairing.pairings.keys.length).to.eql(1);
     expect(peer.core.history.keys.length).to.eql(2);
+    expect(responses[0].topic === responses[1].topic).toBe(true);
   });
 
   it("handles incoming auth requests", async () => {
@@ -173,7 +177,7 @@ describe("AuthClient", () => {
 
     const { uri } = await client.request(defaultRequestParams);
 
-    await peer.core.pairing.pair({ uri });
+    await peer.core.pairing.pair({ uri: uri! });
 
     await waitForEvent(() => receivedAuthRequest);
 
@@ -208,7 +212,7 @@ describe("AuthClient", () => {
     expect(client.core.pairing.getPairings().length).to.eql(1);
     expect(client.core.pairing.getPairings()[0].active).to.eql(false);
 
-    await peer.core.pairing.pair({ uri });
+    await peer.core.pairing.pair({ uri: uri! });
 
     await waitForEvent(() => hasResponded);
 
@@ -248,7 +252,7 @@ describe("AuthClient", () => {
     expect(client.core.pairing.getPairings().length).to.eql(1);
     expect(client.core.pairing.getPairings()[0].active).to.eql(false);
 
-    await peer.core.pairing.pair({ uri });
+    await peer.core.pairing.pair({ uri: uri! });
 
     await waitForEvent(() => hasResponded);
 
@@ -274,7 +278,7 @@ describe("AuthClient", () => {
           ...defaultRequestParams,
           expiry,
         });
-        uri = response.uri;
+        uri = response.uri!;
         resolve();
       }),
     ]);
@@ -313,7 +317,7 @@ describe("AuthClient", () => {
 
       const { uri } = await client.request(defaultRequestParams);
 
-      await peer.core.pairing.pair({ uri });
+      await peer.core.pairing.pair({ uri: uri! });
 
       await waitForEvent(() => receivedAuthRequest);
 
@@ -335,7 +339,7 @@ describe("AuthClient", () => {
 
       const { uri } = await client.request(defaultRequestParams);
 
-      await peer.core.pairing.pair({ uri });
+      await peer.core.pairing.pair({ uri: uri! });
 
       await waitForEvent(() => receivedAuthRequest);
 
@@ -366,7 +370,7 @@ describe("AuthClient", () => {
 
       const { uri } = await client.request(defaultRequestParams);
 
-      await peer.core.pairing.pair({ uri });
+      await peer.core.pairing.pair({ uri: uri! });
 
       await waitForEvent(() => receivedAuthRequest);
 
@@ -395,7 +399,7 @@ describe("AuthClient", () => {
 
       const { uri } = await client.request(defaultRequestParams);
 
-      await peer.core.pairing.pair({ uri });
+      await peer.core.pairing.pair({ uri: uri! });
 
       await waitForEvent(() => receivedAuthRequest);
 
@@ -449,7 +453,7 @@ describe("AuthClient", () => {
     expect(client.core.pairing.getPairings().length).to.eql(1);
     expect(client.core.pairing.getPairings()[0].active).to.eql(false);
 
-    await peer.core.pairing.pair({ uri });
+    await peer.core.pairing.pair({ uri: uri! });
 
     await waitForEvent(() => hasResponded);
 
@@ -480,7 +484,7 @@ describe("AuthClient", () => {
 
     const { uri } = await client.request(defaultRequestParams);
 
-    await peer.core.pairing.pair({ uri });
+    await peer.core.pairing.pair({ uri: uri! });
 
     expect(client.core.pairing.pairings.keys).to.eql(peer.core.pairing.pairings.keys);
     expect(peer.core.pairing.pairings.keys.length).to.eql(1);


### PR DESCRIPTION
# Description

- Fixes #60 
- Fixes #61 
- Fixes an issue with some of the stores not rehydrating properly from persistence

## How Has This Been Tested?

- Unit tests
- Dogfooding in examples

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update
