### PR TITLE
chore(cacao-payload): added chainId in the cacao payload

### DIFF
--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/auth-client",
   "description": "Auth Client for WalletConnect Protocol",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "license": "Apache-2.0",

--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -1,21 +1,21 @@
 import { RELAYER_EVENTS } from "@walletconnect/core";
 import {
+  formatJsonRpcError,
   formatJsonRpcRequest,
   formatJsonRpcResult,
-  formatJsonRpcError,
+  isJsonRpcError,
   isJsonRpcRequest,
   isJsonRpcResponse,
   isJsonRpcResult,
-  isJsonRpcError,
 } from "@walletconnect/jsonrpc-utils";
 import { RelayerTypes } from "@walletconnect/types";
 import { getInternalError, hashKey, TYPE_1 } from "@walletconnect/utils";
-import { JsonRpcTypes, IAuthEngine, AuthEngineTypes } from "../types";
 import { AUTH_CLIENT_PUBLIC_KEY_NAME, ENGINE_RPC_OPTS } from "../constants";
+import { AuthEngineTypes, IAuthEngine, JsonRpcTypes } from "../types";
 import { getDidAddress, getDidChainId, getNamespacedDidChainId } from "../utils/address";
+import { verifySignature } from "../utils/signature";
 import { getPendingRequest, getPendingRequests } from "../utils/store";
 import { isValidRequest, isValidRespond } from "../utils/validators";
-import { verifySignature } from "../utils/signature";
 
 export class AuthEngine extends IAuthEngine {
   private initialized = false;
@@ -328,7 +328,7 @@ export class AuthEngine extends IAuthEngine {
   protected onAuthRequest: IAuthEngine["onAuthRequest"] = async (topic, payload) => {
     const {
       requester,
-      payloadParams: { resources, statement, aud, domain, version, nonce, iat },
+      payloadParams: { resources, statement, aud, domain, version, nonce, iat, chainId },
     } = payload.params;
 
     this.client.logger.info({ type: "onAuthRequest", topic, payload });
@@ -342,6 +342,7 @@ export class AuthEngine extends IAuthEngine {
         iat,
         statement,
         resources,
+        chainId,
       };
 
       await this.client.requests.set(payload.id, {

--- a/packages/auth-client/src/types/engine.ts
+++ b/packages/auth-client/src/types/engine.ts
@@ -1,4 +1,4 @@
-import { RelayerTypes, CryptoTypes } from "@walletconnect/types";
+import { CryptoTypes, RelayerTypes } from "@walletconnect/types";
 
 import {
   ErrorResponse as CommonErrorResponse,
@@ -59,6 +59,7 @@ export declare namespace AuthEngineTypes {
     iat: string;
     nbf?: string;
     exp?: string;
+    chainId?: string;
     statement?: string;
     requestId?: string;
     resources?: string[];


### PR DESCRIPTION
# Description

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->

Resolves #59 
We need to add the chainId in the cacao payload so that apps using the auth-client can get the chainId and display the right SIWE message on authentication request.

## How Has This Been Tested?

This has been E2E tested by using a symlink between `auth-client` and web-examples (`react-dapp-auth` & `react-wallet-auth`)
Instructions:
1. Run `yarn link` in the packages/auth-client folder
2. Head to [web examples](https://github.com/WalletConnect/web-examples) and uninstall @walletconnect/auth-client in both `react-dapp-auth` & `react-wallet-auth`
3. Run `yarn link` in each example

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
