### PR TITLE
fix(engine): ensure AuthEngine only attempts decrypt on own TYPE_1 msgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "canary": "npm run canary --workspaces",
     "test:watch": "npm run test:watch --workspaces",
     "npm-publish": "npm publish --access public --workspaces",
-    "npm-publish:canary": "npm publish --access public --tag canary --workspaces"
+    "npm-publish:canary": "npm publish --access public --tag canary --workspaces",
+    "npm-publish:experimental": "npm publish --access public --tag experimental --workspaces"
   },
   "engines": {
     "node": ">=14"

--- a/packages/auth-client/src/types/client.ts
+++ b/packages/auth-client/src/types/client.ts
@@ -56,7 +56,7 @@ export abstract class IAuthClient {
   public abstract core: ICore;
   public abstract metadata: AuthClientTypes.Metadata;
   public abstract projectId: string;
-  public abstract authKeys: IStore<string, { publicKey: string }>;
+  public abstract authKeys: IStore<string, { responseTopic: string; publicKey: string }>;
   public abstract pairingTopics: IStore<string, any>;
   public abstract requests: IStore<
     number,

--- a/packages/auth-client/src/types/client.ts
+++ b/packages/auth-client/src/types/client.ts
@@ -57,7 +57,7 @@ export abstract class IAuthClient {
   public abstract metadata: AuthClientTypes.Metadata;
   public abstract projectId: string;
   public abstract authKeys: IStore<string, { responseTopic: string; publicKey: string }>;
-  public abstract pairingTopics: IStore<string, any>;
+  public abstract pairingTopics: IStore<string, { topic: string; pairingTopic: string }>;
   public abstract requests: IStore<
     number,
     { id: number } & (AuthEngineTypes.Cacao | AuthEngineTypes.PendingRequest)


### PR DESCRIPTION
# Description

- Dogfooding Auth + Push side by side made it evident that the current clients implicitly decrypt each other's [`TYPE_0` envelope ](https://docs.walletconnect.com/2.0/specs/clients/core/crypto/crypto-envelopes) payloads:
	1. Both clients register an incoming relayer message via the shared `core.relayer`
	2. Both clients call `crypto.decode` on the encrypted `message`
	3. Then only one client will continue processing the payload dependent on the `wc_` RPC method contained within the (now decrypted) payload.
- While being a redundant initial `.decode` for one client, this just worked up to this point because for `TYPE_0` messages the necessary `symKey` is already in the shared keychain for both clients.
- [For `TYPE_1` envelopes](https://docs.walletconnect.com/2.0/specs/clients/core/crypto/crypto-envelopes) the responsible client provides an additional `receiverPublicKey` parameter, which will be undefined in the other client --> **hence we need logic to only attempt decryption on TYPE_1 payloads relevant to this client**.



## Further Action

- The cleaner way to go about this is to only have individual clients attempt decrypt messages for topics they are specifically subscribed to.
- Since clients share `core.relayer`, there's currently no way for clientA to separate what is a topic subscribed to by clientA vs another clientB that is sharing the same relayer instance.
- **Suggestion: we should consider standardising this kind of "own topic" tracking for clients**, either through a pattern or e.g. a `Store` provided by `@walletconnect/core`, but instantiated by each client itself rather than inside `Core`.


## How Has This Been Tested?

- Unit tests
- Dogfooding via `2.0.5-9d74b11` AuthClient canary with PushClient using `TYPE_1` envelopes side by side.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
