### PR TITLE
fix: update homepage URL in package.json

### DIFF
--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -3,7 +3,7 @@
   "description": "Auth Client for WalletConnect Protocol",
   "version": "2.1.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
-  "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
+  "homepage": "https://github.com/WalletConnect/auth-client-js/",
   "license": "Apache-2.0",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
It was incorrectly pointing to https://github.com/WalletConnect/walletconnect-monorepo, so it was hard to find the source code of this package.