### PR TITLE
chore(deps): updates @walletconnect/* deps to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,22 +1580,23 @@
       "link": true
     },
     "node_modules/@walletconnect/core": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.7.2.tgz",
-      "integrity": "sha512-gInSwh3uLpTEkDGArfOFoOVgiXW+zkZJpGqfARVi5fhSxsnL1jYNpqO2k8KAXUPfB4MIzLyaGruiaywncLAczA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-MZYJghS9YCvGe32UOgDj0mCasaOoGHQaYXWeQblXE/xb8HuaM6kAWhjIQN9P+MNp5QP134BHP5olQostcCotXQ==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-provider": "^1.0.12",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -1629,38 +1630,38 @@
       }
     },
     "node_modules/@walletconnect/jsonrpc-provider": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.12.tgz",
-      "integrity": "sha512-6uI2y5281gloZSzICOjk+CVC7CVu0MhtMt2Yzpj05lPb0pzm/bK2oZ2ibxwLerPrqpNt/5bIFVRmoOgPw1mHAQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
       "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.2.tgz",
-      "integrity": "sha512-CZe8tjJX73OWdHjrBHy7HtAapJ2tT0Q3TYhPBhRxi3643lwPIQWC9En45ldY14TZwgSewkbZ0FtGBZK0G7Bbyg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.7.tgz",
-      "integrity": "sha512-zJziApzUF/Il4VcwabnaU+0yo1QI4eUkYX99zmCVTHJvZOf2l0zjADf/OpKqWyeNFC3Io56Z/8uJHVtcNVvyFA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
       "dependencies": {
         "@walletconnect/environment": "^1.0.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.11.tgz",
-      "integrity": "sha512-TiFJ6saasKXD+PwGkm5ZGSw0837nc6EeFmurSPgIT/NofnOV4Tv7CVJqGQN0rQYoJUSYu21cwHNYaFkzNpUN+w==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -1738,33 +1739,32 @@
       }
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.2.tgz",
-      "integrity": "sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.2.tgz",
-      "integrity": "sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha256": "1.0.1",
         "@stablelib/x25519": "^1.0.3",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
+        "@walletconnect/types": "2.9.0",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -5956,19 +5956,19 @@
         "@ethersproject/transactions": "^5.7.0",
         "@stablelib/random": "1.0.2",
         "@stablelib/sha256": "^1.0.1",
-        "@walletconnect/core": "^2.7.2",
+        "@walletconnect/core": "^2.9.0",
         "@walletconnect/events": "^1.0.1",
-        "@walletconnect/heartbeat": "^1.2.0",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/heartbeat": "^1.2.1",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/utils": "^2.7.2",
+        "@walletconnect/utils": "^2.9.0",
         "events": "^3.3.0",
         "isomorphic-unfetch": "^3.1.0"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
-        "@walletconnect/types": "^2.7.2",
+        "@walletconnect/types": "^2.9.0",
         "aws-sdk": "^2.1169.0",
         "lokijs": "^1.5.12"
       },
@@ -6945,14 +6945,14 @@
         "@ethersproject/wallet": "^5.7.0",
         "@stablelib/random": "1.0.2",
         "@stablelib/sha256": "^1.0.1",
-        "@walletconnect/core": "^2.7.2",
+        "@walletconnect/core": "^2.9.0",
         "@walletconnect/events": "^1.0.1",
-        "@walletconnect/heartbeat": "^1.2.0",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/heartbeat": "^1.2.1",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "^2.7.2",
-        "@walletconnect/utils": "^2.7.2",
+        "@walletconnect/types": "^2.9.0",
+        "@walletconnect/utils": "^2.9.0",
         "aws-sdk": "^2.1169.0",
         "events": "^3.3.0",
         "isomorphic-unfetch": "^3.1.0",
@@ -6960,22 +6960,23 @@
       }
     },
     "@walletconnect/core": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.7.2.tgz",
-      "integrity": "sha512-gInSwh3uLpTEkDGArfOFoOVgiXW+zkZJpGqfARVi5fhSxsnL1jYNpqO2k8KAXUPfB4MIzLyaGruiaywncLAczA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-MZYJghS9YCvGe32UOgDj0mCasaOoGHQaYXWeQblXE/xb8HuaM6kAWhjIQN9P+MNp5QP134BHP5olQostcCotXQ==",
       "requires": {
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-provider": "^1.0.12",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
-        "@walletconnect/utils": "2.7.2",
+        "@walletconnect/types": "2.9.0",
+        "@walletconnect/utils": "2.9.0",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -7009,38 +7010,38 @@
       }
     },
     "@walletconnect/jsonrpc-provider": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.12.tgz",
-      "integrity": "sha512-6uI2y5281gloZSzICOjk+CVC7CVu0MhtMt2Yzpj05lPb0pzm/bK2oZ2ibxwLerPrqpNt/5bIFVRmoOgPw1mHAQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
       "requires": {
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
         "tslib": "1.14.1"
       }
     },
     "@walletconnect/jsonrpc-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.2.tgz",
-      "integrity": "sha512-CZe8tjJX73OWdHjrBHy7HtAapJ2tT0Q3TYhPBhRxi3643lwPIQWC9En45ldY14TZwgSewkbZ0FtGBZK0G7Bbyg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
       "requires": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
       }
     },
     "@walletconnect/jsonrpc-utils": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.7.tgz",
-      "integrity": "sha512-zJziApzUF/Il4VcwabnaU+0yo1QI4eUkYX99zmCVTHJvZOf2l0zjADf/OpKqWyeNFC3Io56Z/8uJHVtcNVvyFA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
       "requires": {
         "@walletconnect/environment": "^1.0.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
         "tslib": "1.14.1"
       }
     },
     "@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.11.tgz",
-      "integrity": "sha512-TiFJ6saasKXD+PwGkm5ZGSw0837nc6EeFmurSPgIT/NofnOV4Tv7CVJqGQN0rQYoJUSYu21cwHNYaFkzNpUN+w==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
+      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
       "requires": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -7106,33 +7107,32 @@
       }
     },
     "@walletconnect/types": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.2.tgz",
-      "integrity": "sha512-1O2UefakZpT0ErRfEAXY7Ls3qdUrKDky/DsK088xR6klyfkQOx+aSVH0fJYLhmnqPTuvp3lrqNbsDc0s6/6nvg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
+      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
       "requires": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "events": "^3.3.0"
       }
     },
     "@walletconnect/utils": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.2.tgz",
-      "integrity": "sha512-b2lU/JoWqwCOLMudPSRTt3pliBnv6qQHCBWiMBYi1vL14AW3usO5QmK1wF90AVwpdPJ7wFZ6MgHymeWWfhYnGQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
+      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
       "requires": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha256": "1.0.1",
         "@stablelib/x25519": "^1.0.3",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.2",
+        "@walletconnect/types": "2.9.0",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5949,7 +5949,7 @@
     },
     "packages/auth-client": {
       "name": "@walletconnect/auth-client",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/hash": "^5.7.0",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -38,21 +38,21 @@
   "dependencies": {
     "@ethersproject/hash": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",
-    "@stablelib/random": "1.0.2",
+    "@stablelib/random": "^1.0.2",
     "@stablelib/sha256": "^1.0.1",
-    "@walletconnect/core": "^2.7.2",
+    "@walletconnect/core": "^2.9.0",
     "@walletconnect/events": "^1.0.1",
-    "@walletconnect/heartbeat": "^1.2.0",
-    "@walletconnect/jsonrpc-utils": "^1.0.7",
+    "@walletconnect/heartbeat": "^1.2.1",
+    "@walletconnect/jsonrpc-utils": "^1.0.8",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/utils": "^2.7.2",
+    "@walletconnect/utils": "^2.9.0",
     "events": "^3.3.0",
     "isomorphic-unfetch": "^3.1.0"
   },
   "devDependencies": {
     "@ethersproject/wallet": "^5.7.0",
-    "@walletconnect/types": "^2.7.2",
+    "@walletconnect/types": "^2.9.0",
     "aws-sdk": "^2.1169.0",
     "lokijs": "^1.5.12"
   }


### PR DESCRIPTION
# Description

- Ensure auth-client pulls `2.9.0` and upwards
- Will publish new patch version once validated via canary

## How Has This Been Tested?

- Unit tests
- Canary (`2.1.0-c99633a`)

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
