### PR TITLE
feat: pairing idempotency + persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,23 +1580,23 @@
       "link": true
     },
     "node_modules/@walletconnect/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-MZYJghS9YCvGe32UOgDj0mCasaOoGHQaYXWeQblXE/xb8HuaM6kAWhjIQN9P+MNp5QP134BHP5olQostcCotXQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.1.tgz",
+      "integrity": "sha512-WAoXfmj+Zy5q48TnrKUjmHXJCBahzKwbul+noepRZf7JDtUAZ9IOWpUjg+UPRbfK5EiWZ0TF42S6SXidf7EHoQ==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.13",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/types": "2.10.1",
+        "@walletconnect/utils": "2.10.1",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -1659,9 +1659,9 @@
       }
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
-      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
+      "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -1739,9 +1739,9 @@
       }
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
-      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-7pccAhajQdiH2kYywjE1XI64IqRI+4ioyGy0wvz8d0UFQ/DSG3MLKR8jHf5aTOafQQ/HRLz6xvlzN4a7gIVkUQ==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -1752,9 +1752,9 @@
       }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
-      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.1.tgz",
+      "integrity": "sha512-DM0dKgm9O58l7VqJEyV2OVv16XRePhDAReI23let6WdW1dSpw/Y/A89Lp99ZJOjLm2FxyblMRF3YRaZtHwBffw==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -1764,7 +1764,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
+        "@walletconnect/types": "2.10.1",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -5956,19 +5956,19 @@
         "@ethersproject/transactions": "^5.7.0",
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha256": "^1.0.1",
-        "@walletconnect/core": "^2.9.0",
+        "@walletconnect/core": "^2.10.1",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "^1.2.1",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/utils": "^2.9.0",
+        "@walletconnect/utils": "^2.10.1",
         "events": "^3.3.0",
         "isomorphic-unfetch": "^3.1.0"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
-        "@walletconnect/types": "^2.9.0",
+        "@walletconnect/types": "^2.10.1",
         "aws-sdk": "^2.1169.0",
         "lokijs": "^1.5.12"
       },
@@ -6945,14 +6945,14 @@
         "@ethersproject/wallet": "^5.7.0",
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha256": "^1.0.1",
-        "@walletconnect/core": "^2.9.0",
+        "@walletconnect/core": "^2.10.1",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "^1.2.1",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "^2.9.0",
-        "@walletconnect/utils": "^2.9.0",
+        "@walletconnect/types": "^2.10.1",
+        "@walletconnect/utils": "^2.10.1",
         "aws-sdk": "^2.1169.0",
         "events": "^3.3.0",
         "isomorphic-unfetch": "^3.1.0",
@@ -6960,23 +6960,23 @@
       }
     },
     "@walletconnect/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-MZYJghS9YCvGe32UOgDj0mCasaOoGHQaYXWeQblXE/xb8HuaM6kAWhjIQN9P+MNp5QP134BHP5olQostcCotXQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.1.tgz",
+      "integrity": "sha512-WAoXfmj+Zy5q48TnrKUjmHXJCBahzKwbul+noepRZf7JDtUAZ9IOWpUjg+UPRbfK5EiWZ0TF42S6SXidf7EHoQ==",
       "requires": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.12",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.13",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
-        "@walletconnect/utils": "2.9.0",
+        "@walletconnect/types": "2.10.1",
+        "@walletconnect/utils": "2.10.1",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -7039,9 +7039,9 @@
       }
     },
     "@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.12.tgz",
-      "integrity": "sha512-HAcadga3Qjt1Cqy+qXEW6zjaCs8uJGdGQrqltzl3OjiK4epGZRdvSzTe63P+t/3z+D2wG+ffEPn0GVcDozmN1w==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz",
+      "integrity": "sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==",
       "requires": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -7107,9 +7107,9 @@
       }
     },
     "@walletconnect/types": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.9.0.tgz",
-      "integrity": "sha512-ORopsMfSRvUYqtjKKd6scfg8o4/aGebipLxx92AuuUgMTERSU6cGmIrK6rdLu7W6FBJkmngPLEGc9mRqAb9Lug==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-7pccAhajQdiH2kYywjE1XI64IqRI+4ioyGy0wvz8d0UFQ/DSG3MLKR8jHf5aTOafQQ/HRLz6xvlzN4a7gIVkUQ==",
       "requires": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -7120,9 +7120,9 @@
       }
     },
     "@walletconnect/utils": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.9.0.tgz",
-      "integrity": "sha512-7Tu3m6dZL84KofrNBcblsgpSqU2vdo9ImLD7zWimLXERVGNQ8smXG+gmhQYblebIBhsPzjy9N38YMC3nPlfQNw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.1.tgz",
+      "integrity": "sha512-DM0dKgm9O58l7VqJEyV2OVv16XRePhDAReI23let6WdW1dSpw/Y/A89Lp99ZJOjLm2FxyblMRF3YRaZtHwBffw==",
       "requires": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -7132,7 +7132,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.9.0",
+        "@walletconnect/types": "2.10.1",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -40,19 +40,19 @@
     "@ethersproject/transactions": "^5.7.0",
     "@stablelib/random": "^1.0.2",
     "@stablelib/sha256": "^1.0.1",
-    "@walletconnect/core": "^2.9.0",
+    "@walletconnect/core": "^2.10.1",
     "@walletconnect/events": "^1.0.1",
     "@walletconnect/heartbeat": "^1.2.1",
     "@walletconnect/jsonrpc-utils": "^1.0.8",
     "@walletconnect/logger": "^2.0.1",
     "@walletconnect/time": "^1.0.2",
-    "@walletconnect/utils": "^2.9.0",
+    "@walletconnect/utils": "^2.10.1",
     "events": "^3.3.0",
     "isomorphic-unfetch": "^3.1.0"
   },
   "devDependencies": {
     "@ethersproject/wallet": "^5.7.0",
-    "@walletconnect/types": "^2.9.0",
+    "@walletconnect/types": "^2.10.1",
     "aws-sdk": "^2.1169.0",
     "lokijs": "^1.5.12"
   }

--- a/packages/auth-client/src/client.ts
+++ b/packages/auth-client/src/client.ts
@@ -7,7 +7,7 @@ import {
 } from "@walletconnect/logger";
 import { EventEmitter } from "events";
 
-import { AuthClientTypes, IAuthClient } from "./types";
+import { AuthClientTypes, AuthEngineTypes, IAuthClient } from "./types";
 import { AuthEngine } from "./controllers";
 import {
   AUTH_CLIENT_PROTOCOL,
@@ -69,7 +69,13 @@ export class AuthClient extends IAuthClient {
       "pairingTopics",
       AUTH_CLIENT_STORAGE_PREFIX,
     );
-    this.requests = new Store(this.core, this.logger, "requests", AUTH_CLIENT_STORAGE_PREFIX);
+    this.requests = new Store(
+      this.core,
+      this.logger,
+      "requests",
+      AUTH_CLIENT_STORAGE_PREFIX,
+      (val: AuthEngineTypes.PendingRequest) => val.id,
+    );
     this.engine = new AuthEngine(this);
   }
 

--- a/packages/auth-client/src/controllers/engine.ts
+++ b/packages/auth-client/src/controllers/engine.ts
@@ -436,13 +436,14 @@ export class AuthEngine extends IAuthEngine {
     };
 
     try {
-      const origin = await this.client.core.verify.resolve({
+      const result = await this.client.core.verify.resolve({
         attestationId: hash,
         verifyUrl: metadata.verifyUrl,
       });
-      if (origin) {
-        context.verified.origin = origin;
-        context.verified.validation = origin === metadata.url ? "VALID" : "INVALID";
+      if (result) {
+        context.verified.origin = result.origin;
+        context.verified.isScam = result.isScam;
+        context.verified.validation = origin === new URL(metadata.url).origin ? "VALID" : "INVALID";
       }
     } catch (e) {
       this.client.logger.error(e);

--- a/packages/auth-client/src/types/engine.ts
+++ b/packages/auth-client/src/types/engine.ts
@@ -1,4 +1,4 @@
-import { CryptoTypes, RelayerTypes } from "@walletconnect/types";
+import { CryptoTypes, RelayerTypes, Verify } from "@walletconnect/types";
 
 import {
   ErrorResponse as CommonErrorResponse,
@@ -91,6 +91,7 @@ export declare namespace AuthEngineTypes {
       metadata: AuthClientTypes.Metadata;
     };
     cacaoPayload: CacaoRequestPayload;
+    verifyContext: Verify.Context;
   }
 
   interface ResultResponse {

--- a/packages/auth-client/test/canary/canary.spec.ts
+++ b/packages/auth-client/test/canary/canary.spec.ts
@@ -114,7 +114,7 @@ describe("AuthClient canary", () => {
         });
       }),
       new Promise<void>(async (resolve) => {
-        await peer.core.pairing.pair({ uri: request.uri!, activatePairing: true });
+        await peer.core.pairing.pair({ uri: request.uri! });
         resolve();
       }),
     ]);

--- a/packages/auth-client/test/client.spec.ts
+++ b/packages/auth-client/test/client.spec.ts
@@ -112,7 +112,7 @@ describe("AuthClient", () => {
     });
     const { uri } = await client.request(defaultRequestParams);
 
-    await peer.core.pairing.pair({ uri: uri!, activatePairing: true });
+    await peer.core.pairing.pair({ uri: uri! });
     await waitForEvent(() => hasRequest);
 
     // Ensure they paired
@@ -124,7 +124,8 @@ describe("AuthClient", () => {
     expect(client.core.history.records.size).to.eql(1);
 
     // Ensure pairing is in expected state
-    expect(peer.core.pairing.pairings.values[0].active).to.eql(true);
+    // pairing should only activates on successful response i.e. auth approval
+    expect(peer.core.pairing.pairings.values[0].active).to.eql(false);
   });
 
   it("can use known pairings", async () => {

--- a/packages/auth-client/test/persistence/persistence.spec.ts
+++ b/packages/auth-client/test/persistence/persistence.spec.ts
@@ -1,0 +1,162 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { expect, describe, it, beforeEach, afterEach, beforeAll } from "vitest";
+import { Wallet } from "@ethersproject/wallet";
+import { AuthClient, generateNonce, IAuthClient, AuthEngineTypes } from "../../src";
+import { disconnectSocket } from "../helpers/ws";
+import { uploadCanaryResultsToCloudWatch } from "../utils";
+
+const metadataRequester = {
+  name: "client (requester)",
+  description: "Test Client as Requester",
+  url: "www.walletconnect.com",
+  icons: [],
+};
+
+const metadataResponder = {
+  name: "peer (responder)",
+  description: "Test Client as Peer/Responder",
+  url: "www.walletconnect.com",
+  icons: [],
+};
+
+const defaultRequestParams: AuthEngineTypes.RequestParams = {
+  aud: "http://localhost:3000/login",
+  domain: "localhost:3000",
+  chainId: "eip155:1",
+  nonce: generateNonce(),
+};
+
+const TEST_RELAY_URL = process.env.TEST_RELAY_URL || "wss://relay.walletconnect.com";
+
+const dbName = "./tmp/test.db";
+describe("AuthClient persistence tests", () => {
+  let wallet: Wallet;
+  let iss: string;
+
+  // Set up a wallet to use as the external signer.
+  beforeAll(() => {
+    wallet = Wallet.createRandom();
+  });
+
+  it("Pairs", async () => {
+    const client = await AuthClient.init({
+      name: "testClient",
+      logger: "error",
+      relayUrl: TEST_RELAY_URL,
+      projectId: process.env.TEST_PROJECT_ID!,
+      storageOptions: {
+        database: ":memory:",
+      },
+      metadata: metadataRequester,
+    });
+
+    let peer = await AuthClient.init({
+      name: "testPeer",
+      logger: "error",
+      relayUrl: TEST_RELAY_URL,
+      projectId: process.env.TEST_PROJECT_ID!,
+      storageOptions: {
+        database: dbName,
+      },
+      metadata: metadataResponder,
+    });
+
+    iss = `did:pkh:eip155:1:${wallet.address}`;
+
+    const request = await client.request(defaultRequestParams);
+    // receive the request and ignore it
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        peer.once("auth_request", (args) => {
+          expect(args.params).to.exist;
+          expect(args.topic).to.exist;
+          expect(args.verifyContext).to.exist;
+          resolve();
+        });
+      }),
+      new Promise<void>(async (resolve) => {
+        await peer.core.pairing.pair({ uri: request.uri! });
+        resolve();
+      }),
+    ]);
+
+    // disconnect peer
+    await disconnectSocket(peer.core);
+
+    peer = await AuthClient.init({
+      name: "testPeer",
+      logger: "error",
+      relayUrl: TEST_RELAY_URL,
+      projectId: process.env.TEST_PROJECT_ID!,
+      storageOptions: {
+        database: dbName,
+      },
+      metadata: metadataResponder,
+    });
+    // pair with the same URI
+    // should be able to process the request normally
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        peer.once("auth_request", async (args) => {
+          const message = peer.formatMessage(args.params.cacaoPayload, iss);
+          const signature = await wallet.signMessage(message);
+          await peer.respond(
+            {
+              id: args.id,
+              signature: {
+                s: signature,
+                t: "eip191",
+              },
+            },
+            iss,
+          );
+          resolve();
+        });
+      }),
+      new Promise<void>((resolve) => {
+        client.once("auth_response", (args) => {
+          expect(args.id).to.equal(request.id);
+          resolve();
+        });
+      }),
+      new Promise<void>(async (resolve) => {
+        await peer.core.pairing.pair({ uri: request.uri! });
+        resolve();
+      }),
+    ]);
+
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        peer.core.pairing.events.once("pairing_ping", () => {
+          resolve();
+        });
+      }),
+      new Promise<void>((resolve) => {
+        client.core.pairing.events.once("pairing_ping", () => {
+          resolve();
+        });
+      }),
+      new Promise<void>(async (resolve) => {
+        const topic = client.core.pairing.pairings.keys[0];
+        await client.core.pairing.ping({ topic });
+        await peer.core.pairing.ping({ topic });
+        resolve();
+      }),
+    ]);
+
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        peer.core.pairing.events.once("pairing_delete", () => {
+          resolve();
+        });
+      }),
+      new Promise<void>(async (resolve) => {
+        await client.core.pairing.disconnect({ topic: client.core.pairing.getPairings()[0].topic });
+        resolve();
+      }),
+    ]);
+
+    await disconnectSocket(client.core);
+    await disconnectSocket(peer.core);
+  });
+});


### PR DESCRIPTION
# Description
Updated `Auth Client` to be on par with `Sign Client` in terms of pairing handling. Also implemented several improvements such as the persistence of pending auth requests that were missing.
PR includes updates for 
- Persisting `verifyContext` as part of pending auth requests
- Loading pending auth requests after client restart
- Added persistence tests
- Implemented pairing idempotency e.g. being able to rescan the same URI
- Added `exp, nbf` to CACAO object as they were ignored even if populated by the peer

## How Has This Been Tested?
dogfooding
tests
## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
